### PR TITLE
Bump v0.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SparseArrayKit"
 uuid = "a9a3c162-d163-4c15-8926-b8794fbefed2"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Maarten Van Damme <maartenvd1994@gmail.com>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "0.4"
+version = "0.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/base.jl
+++ b/src/base.jl
@@ -10,10 +10,10 @@ function Base.:/(x::SparseArray, a::Number)
     return mul!(similar(x, Base.promote_eltypeof(a, x)), x, inv(a))
 end
 function Base.:+(x::SparseArray, y::SparseArray)
-    return (T = Base.promote_eltypeof(x, y); axpy!(+one(T), y, copy!(similar(x, T), x)))
+    return (T=Base.promote_eltypeof(x, y); axpy!(+one(T), y, copy!(similar(x, T), x)))
 end
 function Base.:-(x::SparseArray, y::SparseArray)
-    return (T = Base.promote_eltypeof(x, y); axpy!(-one(T), y, copy!(similar(x, T), x)))
+    return (T=Base.promote_eltypeof(x, y); axpy!(-one(T), y, copy!(similar(x, T), x)))
 end
 
 Base.:-(x::SparseArray) = LinearAlgebra.lmul!(-one(eltype(x)), copy(x))


### PR DESCRIPTION
Just noticed that the latest commits haven't been tagged and released, in particular this  includes the VectorInterface v0.5 compat bounds.
This should be merged and tagged :)
Fixes #18 
Should also fix: https://github.com/lkdvos/CategoryData.jl/issues/27
