### PR TITLE
CI maintenance: native macOS arch + Julia Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups: # group all julia package updates into a single PR
+      all-julia-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
@@ -32,14 +32,13 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          # arch omitted: defaults to the runner's native arch
+          # (macOS-latest is Apple Silicon / aarch64)
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
@@ -51,7 +50,7 @@ jobs:
           fail_ci_if_error: false
   test-nightly:
     needs: test
-    name: Julia nightly - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia nightly - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
@@ -65,14 +64,11 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest


### PR DESCRIPTION
A couple of maintenance updates to bring SparseArrayKit in line with the rest of the ecosystem.

## CI: fix macOS architecture
All three `macOS-latest` jobs were failing because the matrix forced `arch: x64`, but `macOS-latest` now points to Apple Silicon (arm64) runners:

> [setup-julia] x64 arch has been requested on a macOS runner that has an arm64 (Apple Silicon) architecture.

This drops the `arch: x64` axis so each runner uses its native architecture (ubuntu/windows → x64, macOS → aarch64), which is also what the reusable ecosystem workflow does.

## Dependabot: add Julia package updates
Dependabot now supports the `julia` ecosystem natively. This adds it (grouped into a single PR) alongside the existing `github-actions` updates, matching e.g. MPSKit.jl.

---

Follow-ups not included here (happy to do separately):
- `julia-actions/julia-buildpkg@latest` / `julia-runtest@latest` could be pinned to `@v1` so Dependabot can track them.
- The standalone `ci.yml` could eventually migrate to the reusable `QuantumKitHubActions/.github/workflows/TestGroups.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)